### PR TITLE
Fix simple JSON syntax issues

### DIFF
--- a/examples/Oresteia.json
+++ b/examples/Oresteia.json
@@ -678,7 +678,7 @@
   "propertyBundle": [
     {
       "@type": "PhoneAccount",
-      "phoneNumber": "1237771337",
+      "phoneNumber": "1237771337"
     }
    ]
    },

--- a/examples/accounts.json
+++ b/examples/accounts.json
@@ -57,7 +57,7 @@
           "accountLogin": "xXWillyRocksXx",
           "firstLoginTime": "2010-01-21T17:59:43.25Z",
           "lastLoginTime": "2010-03-12T17:59:43.25Z",
-          "displayName": "WILLY THE KID",
+          "displayName": "WILLY THE KID"
         },
         {
           "@type": "AccountAuthentication",
@@ -75,7 +75,7 @@
         },
         {
           "@type": "BirthInformation",
-          "birthdate": "1968-09-25T17:59:43.25Z",
+          "birthdate": "1968-09-25T17:59:43.25Z"
         }
       ]
     },
@@ -95,7 +95,7 @@
           "@type": "Account",
           "accountIdentifier": "willyROX@gmail.com",
           "accountIssuer": "google_org",
-          "createdTime": "2010-01-15T17:59:43.25Z",
+          "createdTime": "2010-01-15T17:59:43.25Z"
         },
         {
           "@type": "DigitalAccount",
@@ -105,7 +105,7 @@
           ],
           "firstLoginTime": "2010-01-21T17:59:43.25Z",
           "lastLoginTime": "2010-03-12T17:59:43.25Z",
-          "displayName": "William Smith",
+          "displayName": "William Smith"
         },
         {
           "@type": "AccountAuthentication",
@@ -119,11 +119,11 @@
         {
           "@type": "SimpleName",
           "givenName": "William",
-          "familyName": "Smith",
+          "familyName": "Smith"
         },
         {
           "@type": "BirthInformation",
-          "birthdate": "1968-09-25T17:59:43.25Z",
+          "birthdate": "1968-09-25T17:59:43.25Z"
         }
       ]
     },

--- a/examples/device.json
+++ b/examples/device.json
@@ -30,7 +30,7 @@
         },
         {
           "@type": "DomainName",
-          "value": "dfl.local",
+          "value": "dfl.local"
         },
         {
           "@type": "IPv4Address",

--- a/examples/exif_data.json
+++ b/examples/exif_data.json
@@ -55,7 +55,7 @@
               "hashValue": "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b"
             }
           ]
-        }
+        },
         {
           "@type": "RasterPicture",
           "pictureType": "jpg",

--- a/examples/forensic_lifecycle.json
+++ b/examples/forensic_lifecycle.json
@@ -70,7 +70,7 @@
       ],
       "object": ["investigator1", "examiner1", "examiner2", "subject1", "victim2", "forensic_action1", "lifecycle_phase1",
         "annotation2", "forensic_action2","lifecycle_phase2", "annotation3", "forensic_action3", "lifecycle_phase3",
-        "annotation4", "forensic_action4","lifecycle_phase4", "annotation5", "forensic_action5", "lifecycle_phase5"
+        "annotation4", "forensic_action4","lifecycle_phase4", "annotation5", "forensic_action5", "lifecycle_phase5",
         "annotation6", "forensic_action6", "provenance_record1", "provenance_record2", "provenance_record3",
         "provenance_record4", "provenance_record5", "provenance_record6", "provenance_record7", "provenance_record8",
         "provenance_record9", "provenance_record10", "provenance_record11", "provenance_record12", "provenance_record13",

--- a/examples/message.json
+++ b/examples/message.json
@@ -1,7 +1,7 @@
 {
   "@context": {
     "@vocab": "http://case.example.org/core#",
-    "olo": "http://purl.org/ontology/olo/core#",
+    "olo": "http://purl.org/ontology/olo/core#"
   },
   "@graph": [
     {

--- a/examples/sms_and_contacts.json
+++ b/examples/sms_and_contacts.json
@@ -1,7 +1,7 @@
 {
   "@context": {
     "@vocab": "http://case.example.org/core#",
-    "olo": "http://purl.org/ontology/olo/core#",
+    "olo": "http://purl.org/ontology/olo/core#"
   },
   "@graph": [
 


### PR DESCRIPTION
The Python JSON library failed to parse some files because of simple
matters like missing or extra commas.  These issues were found with this
Bash/Python one-liner:

    ls *json | while read x; do python -c 'import json, sys ; json.load(open(sys.argv[1], "r"))' $x || echo "Problem parsing $x." >&2; done

This patch leaves alone two files that can't be parsed because they
include inline TODOs added with `//`-style commenting.

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>