### PR TITLE
Add rootExhibitNumber property to ProvenanceRecord

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,5 @@
+2021-05-24
+	* ONT-403, CP-22: Added rootExhibitNumber property to ProvenanceRecord
 
 2021-04-28
 	* ONT-390, CP-21: Add direct node-linking predicates for transitive provenance querying

--- a/ontology/investigation/investigation.ttl
+++ b/ontology/investigation/investigation.ttl
@@ -141,6 +141,12 @@ investigation:ProvenanceRecord
 			owl:onProperty investigation:exhibitNumber ;
 			owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
 			owl:onDataRange xsd:string ;
+		] ,
+		[
+			a owl:Restriction ;
+			owl:onProperty investigation:rootExhibitNumber ;
+			owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+			owl:onDataRange xsd:string ;
 		]
 		;
 	rdfs:label "ProvenanceRecord"@en ;
@@ -215,6 +221,13 @@ investigation:relevantAuthorization
 	rdfs:label "relevantAuthorization"@en ;
 	rdfs:comment "Specifies an authorization relevant to a particular investigation."@en ;
 	rdfs:range investigation:Authorization ;
+	.
+
+investigation:rootExhibitNumber
+	a owl:DatatypeProperty ;
+	rdfs:label "rootExhibitNumber"@en ;
+	rdfs:comment "Specifies a unique identifier assigned to a given object at the start of its treatment as part of an investigation. The first node in a provenance chain, which can be viewed as a heirarchical tree originating from a single root."@en ;
+	rdfs:range xsd:string ;
 	.
 
 investigation:wasDerivedFrom


### PR DESCRIPTION
Note that there are known issues with the definition for this property.
However, in consideration of its interaction with another proposed
definition (CP-35) and with CASE 0.4.0 release timing, a follow-on
proposal will handle aligning the definitions (CP-36).

References:
* [ONT-403] (CP-22) Add rootExhibitNumber property to ProvenanceRecord
* [ONT-436] (CP-35) exhibitNumber does not have a definition
* [ONT-438] (CP-36) Correct rootExhibitNumber definition issues and
  align with exhibitNumber

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>