### PR TITLE
Closing out CP-38/ont-445: added CP-38 docs link

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2021-08-04
+	* CP-38: https://drive.google.com/file/d/1T7ZmDZuslKAGc2HA3PPYhSmKqDDoqfkt/view
+
 2021-06-01
 	* ONT-445, CP-38: Removed "base IRI" features from ontology and normalization procedure
 


### PR DESCRIPTION
Couldn't merge into branch release-0.2.1 because that one is a protected branch. Hence this work around. @ajnelson-nist to approve and merge.