### PR TITLE
Track UCO as a Git submodule, at version 0.7.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 *.pyo
 
 # Unit testing files
-.lib.done.log
+.*.done.log
 .*.ttl
 
 # Pycharm files

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "dependencies/UCO"]
+	path = dependencies/UCO
+	url = https://github.com/ucoProject/UCO.git

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2021-09-17
+	* ONT-455, CP-40: Adopted UCO 0.7.0 as a Git submodule
+
 2021-09-08
 	* ONT-442, CP-37: Fixed broken link to website examples gallery in README
 

--- a/Makefile
+++ b/Makefile
@@ -13,19 +13,32 @@
 
 all:
 
+# This recipe guarantees that 'git submodule init' and 'git submodule update' have run at least once.
+# The recipe avoids running 'git submodule update' more than once, in case a user is testing with the submodule at a different commit than what CASE tracks.
+.git_submodule_init.done.log: \
+  .gitmodules
+	# UCO
+	test -r dependencies/UCO/README.md \
+	  || (git submodule init dependencies/UCO && git submodule update dependencies/UCO)
+	@test -r dependencies/UCO/README.md \
+	  || (echo "ERROR:Makefile:UCO submodule README.md file not found, even though that submodule is initialized." >&2 ; exit 2)
+	touch $@
+
 .lib.done.log:
 	$(MAKE) \
 	  --directory lib
 	touch $@
 
 check: \
+  .git_submodule_init.done.log \
   .lib.done.log
 	$(MAKE) \
 	  --directory ontology \
 	  check
 
 clean:
-	@rm -f .lib.done.log
 	@$(MAKE) \
 	  --directory ontology \
 	  clean
+	@rm -f \
+	  .*.done.log


### PR DESCRIPTION
References:
* [ONT-455] (CP-40) UCO 0.7.0 should be adopted as a Git submodule

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>