### PR TITLE
Remove investigation-namespaced startTime and endTime properties from…

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2021-09-17
+	* ONT-462, CP-42: Removed investigation-namespaced startTime and endTime properties from investigation-da.ttl
+
 2021-09-08
 	* ONT-442, CP-37: Fixed broken link to website examples gallery in README
 

--- a/ontology/investigation/investigation-da.ttl
+++ b/ontology/investigation/investigation-da.ttl
@@ -21,10 +21,6 @@ investigation:authorizationType
 	rdfs:domain investigation:Authorization ;
 	.
 
-investigation:endTime
-	rdfs:domain investigation:Investigation ;
-	.
-
 investigation:exhibitNumber
 	rdfs:domain investigation:ProvenanceRecord ;
 	.
@@ -42,10 +38,6 @@ investigation:investigationStatus
 	.
 
 investigation:relevantAuthorization
-	rdfs:domain investigation:Investigation ;
-	.
-
-investigation:startTime
 	rdfs:domain investigation:Investigation ;
 	.
 


### PR DESCRIPTION
… investigation-da.ttl

References:
* [ONT-462] (CP-42) investigation-da.ttl contains errant startTime and
  endTime definitions

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>