### PR TITLE
Release 0.7.1

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
-2022-06-16
+2022-06-17
 	* ONT-476: Release CASE 0.7.0, with release notes at https://caseontology.org/releases/0.7.0/
+
+2022-06-16
 	* (3d13cc1): Adopt UCO 0.9.0
 
 2022-06-14

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2022-08-31
+	* ONT-410: Release CASE 0.7.1, with release notes at https://caseontology.org/releases/0.7.1/
+	* (e673017): UCO OC-217, CP-107: Revise ontology IRI to be slash-based and drop IRI base
+	* (0e7337e): UCO Issue 437: Adopt versionIRI practice prepared for UCO 0.9.1
+
 2022-06-17
 	* ONT-476: Release CASE 0.7.0, with release notes at https://caseontology.org/releases/0.7.0/
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 2022-08-31
 	* ONT-410: Release CASE 0.7.1, with release notes at https://caseontology.org/releases/0.7.1/
+	* (5b8c03f): UCO Issue 437: Adopt UCO 0.9.1
 	* (e673017): UCO OC-217, CP-107: Revise ontology IRI to be slash-based and drop IRI base
 	* (0e7337e): UCO Issue 437: Adopt versionIRI practice prepared for UCO 0.9.1
 

--- a/ontology/investigation/Makefile
+++ b/ontology/investigation/Makefile
@@ -19,7 +19,6 @@ all:
   $(top_srcdir)/.lib.done.log \
   investigation.ttl
 	java -jar $(top_srcdir)/dependencies/UCO/lib/rdf-toolkit.jar \
-	  --infer-base-iri \
 	  --inline-blank-nodes \
 	  --source investigation.ttl \
 	  --source-format turtle \

--- a/ontology/investigation/investigation.ttl
+++ b/ontology/investigation/investigation.ttl
@@ -1,11 +1,9 @@
-# baseURI: https://ontology.caseontology.org/case/investigation
 # imports: https://ontology.caseontology.org/case/vocabulary
 # imports: https://ontology.unifiedcyberontology.org/uco/action
 # imports: https://ontology.unifiedcyberontology.org/uco/core
 # imports: https://ontology.unifiedcyberontology.org/uco/location
 # imports: https://ontology.unifiedcyberontology.org/uco/role
 
-@base <https://ontology.caseontology.org/case/investigation> .
 @prefix investigation: <https://ontology.caseontology.org/case/investigation/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/ontology/investigation/investigation.ttl
+++ b/ontology/investigation/investigation.ttl
@@ -1,9 +1,7 @@
 # baseURI: https://ontology.caseontology.org/case/investigation
-# imports: https://ontology.caseontology.org/case/vocabulary
-# imports: https://ontology.unifiedcyberontology.org/uco/action
-# imports: https://ontology.unifiedcyberontology.org/uco/core
-# imports: https://ontology.unifiedcyberontology.org/uco/location
-# imports: https://ontology.unifiedcyberontology.org/uco/role
+# imports: https://ontology.caseontology.org/case/vocabulary/0.7.1
+# imports: https://ontology.unifiedcyberontology.org/uco/action/0.9.1
+# imports: https://ontology.unifiedcyberontology.org/uco/role/0.9.1
 
 @base <https://ontology.caseontology.org/case/investigation> .
 @prefix investigation: <https://ontology.caseontology.org/case/investigation/> .
@@ -22,12 +20,12 @@
 	rdfs:label "investigation"@en ;
 	rdfs:comment "This ontology defines key concepts, and their associated properties and relationships, for characterizing cyber-investigations in the broadest range of contexts, including security incidents, criminal investigations, civil and regulatory matters, intelligence operations, international disputes, accident inquiries, policy violations, and others." ;
 	owl:imports
-		<https://ontology.caseontology.org/case/vocabulary> ,
-		<https://ontology.unifiedcyberontology.org/uco/action> ,
-		<https://ontology.unifiedcyberontology.org/uco/core> ,
-		<https://ontology.unifiedcyberontology.org/uco/location> ,
-		<https://ontology.unifiedcyberontology.org/uco/role>
+		vocabulary:0.7.1 ,
+		uco-action:0.9.1 ,
+		uco-role:0.9.1
 		;
+	owl:ontologyIRI <https://ontology.caseontology.org/case/investigation> ;
+	owl:versionIRI investigation:0.7.1 ;
 	.
 
 investigation:Attorney

--- a/ontology/master/Makefile
+++ b/ontology/master/Makefile
@@ -19,7 +19,6 @@ all:
   $(top_srcdir)/.lib.done.log \
   case.ttl
 	java -jar $(top_srcdir)/dependencies/UCO/lib/rdf-toolkit.jar \
-	  --infer-base-iri \
 	  --inline-blank-nodes \
 	  --source case.ttl \
 	  --source-format turtle \

--- a/ontology/master/case.ttl
+++ b/ontology/master/case.ttl
@@ -1,9 +1,7 @@
-# baseURI: https://ontology.caseontology.org/case/case
 # imports: https://ontology.caseontology.org/case/investigation
 # imports: https://ontology.caseontology.org/case/vocabulary
 # imports: https://ontology.unifiedcyberontology.org/uco/uco
 
-@base <https://ontology.caseontology.org/case/case> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/ontology/master/case.ttl
+++ b/ontology/master/case.ttl
@@ -1,7 +1,7 @@
 # baseURI: https://ontology.caseontology.org/case/case
-# imports: https://ontology.caseontology.org/case/investigation
-# imports: https://ontology.caseontology.org/case/vocabulary
-# imports: https://ontology.unifiedcyberontology.org/uco/uco
+# imports: https://ontology.caseontology.org/case/investigation/0.7.1
+# imports: https://ontology.caseontology.org/case/vocabulary/0.7.1
+# imports: https://ontology.unifiedcyberontology.org/uco/uco/0.9.1
 
 @base <https://ontology.caseontology.org/case/case> .
 @prefix dct: <http://purl.org/dc/terms/> .
@@ -19,13 +19,12 @@
 	rdfs:comment "The Cyber-investigation Analysis Standard Expression (CASE) ontology is a community-developed standard that defines concepts used in a broad range of cyber-investigation domains, including digital forensic science, incident response, counter-terrorism, criminal justice, forensic intelligence, and situational awareness. CASE includes all aspects of the digital forensic process, from evidence-gathering and chain of custody, to generating a final report. The goal is to increase sharing and interoperability of cyber-investigation information among organizations and between forensic analytic tools. CASE aligns with and extends the Unified Cyber Ontology (UCO). The preferred namespace abbreviation for this ontology is: case-master."@en ;
 	dct:title "Cyber-investigation Analysis Standard Expression (CASE)"@en ;
 	owl:imports
-		<https://ontology.caseontology.org/case/investigation> ,
-		<https://ontology.caseontology.org/case/vocabulary> ,
-		<https://ontology.unifiedcyberontology.org/uco/uco>
+		<https://ontology.caseontology.org/case/investigation/0.7.1> ,
+		<https://ontology.caseontology.org/case/vocabulary/0.7.1> ,
+		<https://ontology.unifiedcyberontology.org/uco/uco/0.9.1>
 		;
-	owl:incompatibleWith <http://case.example.org/core> ;
 	owl:ontologyIRI <https://ontology.caseontology.org/case/case> ;
-	owl:priorVersion <http://case.example.org/core> ;
-	owl:versionInfo "0.7.0" ;
+	owl:versionIRI <https://ontology.caseontology.org/case/case/0.7.1> ;
+	owl:versionInfo "0.7.1" ;
 	.
 

--- a/ontology/vocabulary/Makefile
+++ b/ontology/vocabulary/Makefile
@@ -19,7 +19,6 @@ all:
   $(top_srcdir)/.lib.done.log \
   vocabulary.ttl
 	java -jar $(top_srcdir)/dependencies/UCO/lib/rdf-toolkit.jar \
-	  --infer-base-iri \
 	  --inline-blank-nodes \
 	  --source vocabulary.ttl \
 	  --source-format turtle \

--- a/ontology/vocabulary/vocabulary.ttl
+++ b/ontology/vocabulary/vocabulary.ttl
@@ -1,6 +1,3 @@
-# baseURI: https://ontology.caseontology.org/case/vocabulary
-
-@base <https://ontology.caseontology.org/case/vocabulary> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .

--- a/ontology/vocabulary/vocabulary.ttl
+++ b/ontology/vocabulary/vocabulary.ttl
@@ -10,6 +10,8 @@
 <https://ontology.caseontology.org/case/vocabulary>
 	a owl:Ontology ;
 	rdfs:label "vocabularies"@en ;
+	owl:ontologyIRI <https://ontology.caseontology.org/case/vocabulary> ;
+	owl:versionIRI vocab:0.7.1 ;
 	.
 
 vocab:InvestigationFormVocab

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -57,7 +57,6 @@ case_monolithic.ttl: \
 	    $(case_turtle_files) \
 	    $(uco_turtle_files)
 	java -jar $(top_srcdir)/dependencies/UCO/lib/rdf-toolkit.jar \
-	  --infer-base-iri \
 	  --inline-blank-nodes \
 	  --source __$@ \
 	  --source-format turtle \

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -120,7 +120,7 @@ clean:
 	  --directory examples \
 	  clean
 	@rm -f \
-	  .venv.done.log \
+	  .*.done.log \
 	  case_monolithic.ttl
 	@rm -rf \
 	  venv

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -22,6 +22,15 @@ uco_turtle_files := $(shell /bin/ls $(top_srcdir)/dependencies/UCO/ontology/*/*.
 
 all:
 
+# Ensure the CASE-internal shapes pass their own tests.
+.shapes.done.log: \
+  .venv.done.log \
+  shapes/case-qc.ttl
+	$(MAKE) \
+	  --directory shapes \
+	  check
+	touch $@
+
 # The two CASE-Utility... files are to trigger rebuilds based on command-line interface changes or version increments.
 .venv.done.log: \
   $(top_srcdir)/.git_submodule_init.done.log \
@@ -50,12 +59,45 @@ case_monolithic.ttl: \
   $(top_srcdir)/dependencies/UCO/tests/src/glom_graph.py \
   $(case_turtle_files) \
   $(uco_turtle_files) \
-  .venv.done.log
+  .shapes.done.log
 	source venv/bin/activate \
 	  && python3 $(top_srcdir)/dependencies/UCO/tests/src/glom_graph.py \
 	    __$@ \
 	    $(case_turtle_files) \
 	    $(uco_turtle_files)
+	# Review CASE for OWL 2 DL versioning conformance.
+	source venv/bin/activate \
+	  && pyshacl \
+	    --data-file-format turtle \
+	    --format turtle \
+	    --inference none \
+	    --shacl $(top_srcdir)/dependencies/UCO/tests/shapes/uco-owl.ttl \
+	    --shacl-file-format turtle \
+	    __$@
+	source venv/bin/activate \
+	  && pyshacl \
+	    --data-file-format turtle \
+	    --format turtle \
+	    --inference none \
+	    --shacl $(top_srcdir)/dependencies/UCO/tests/shapes/uco-closure-qc.ttl \
+	    --shacl-file-format turtle \
+	    __$@
+	source venv/bin/activate \
+	  && pyshacl \
+	    --data-file-format turtle \
+	    --format turtle \
+	    --inference none \
+	    --shacl $(top_srcdir)/dependencies/UCO/tests/shapes/uco-qc.ttl \
+	    --shacl-file-format turtle \
+	    __$@
+	source venv/bin/activate \
+	  && pyshacl \
+	    --data-file-format turtle \
+	    --format turtle \
+	    --inference none \
+	    --shacl shapes/case-qc.ttl \
+	    --shacl-file-format turtle \
+	    __$@
 	java -jar $(top_srcdir)/dependencies/UCO/lib/rdf-toolkit.jar \
 	  --infer-base-iri \
 	  --inline-blank-nodes \

--- a/tests/shapes/Makefile
+++ b/tests/shapes/Makefile
@@ -1,0 +1,53 @@
+#!/usr/bin/make -f
+
+# This software was developed at the National Institute of Standards
+# and Technology by employees of the Federal Government in the course
+# of their official duties. Pursuant to title 17 Section 105 of the
+# United States Code this software is not subject to copyright
+# protection and is in the public domain. NIST assumes no
+# responsibility whatsoever for its use by other parties, and makes
+# no guarantees, expressed or implied, about its quality,
+# reliability, or any other characteristic.
+#
+# We would appreciate acknowledgement if the software is used.
+
+SHELL := /bin/bash
+
+top_srcdir := $(shell cd ../.. ; pwd)
+
+tests_srcdir := $(top_srcdir)/tests
+
+all: \
+  .check-case-qc.ttl
+
+.PHONY: \
+  check-%.ttl
+
+.PRECIOUS: \
+  .check-%.ttl
+
+.check-%.ttl: \
+  %.ttl \
+  $(top_srcdir)/.lib.done.log
+	java -jar $(top_srcdir)/dependencies/UCO/lib/rdf-toolkit.jar \
+	  --inline-blank-nodes \
+	  --source $< \
+	  --source-format turtle \
+	  --target $@_ \
+	  --target-format turtle
+	mv $@_ $@
+
+check: \
+  check-case-qc.ttl
+
+# Reminder: diff exits non-0 on finding any differences.
+# Reminder: The $^ automatic Make variable is the name of all recipe prerequisites.
+check-%.ttl: \
+  %.ttl \
+  .check-%.ttl
+	diff $^ \
+	  || (echo "ERROR:tests/shapes/Makefile:The local $< does not match the normalized version. If the above reported changes look fine, run 'cp .check-$< $<' while in the sub-folder tests/shapes/ to get a file ready to commit to Git." >&2 ; exit 1)
+
+clean:
+	@rm -f \
+	  .check-*.ttl*

--- a/tests/shapes/case-qc.ttl
+++ b/tests/shapes/case-qc.ttl
@@ -1,0 +1,71 @@
+@prefix case-qc: <urn:example:case:qc:> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<urn:example:case:qc>
+	a owl:Ontology ;
+	rdfs:comment "This ontology contains shapes meant to be used against the transitive closure of CASE, excluding imported ontologies developed externally to UCO."@en ;
+	.
+
+case-qc:owl-Ontology-shape
+	a sh:NodeShape ;
+	sh:sparql
+		[
+			a sh:SPARQLConstraint ;
+			sh:message "CASE imports of other CASE and UCO ontologies are expected to be of versionIRIs."@en ;
+			sh:select '''
+				SELECT $this ?value
+				WHERE {
+					$this owl:imports ?value .
+					FILTER (
+						STRSTARTS (
+							STR(?value),
+							"https://ontology.caseontology.org/"
+						)
+						||
+						STRSTARTS (
+							STR(?value),
+							"https://ontology.unifiedcyberontology.org/"
+						)
+					)
+					FILTER NOT EXISTS {
+						?nOtherUcoOntology
+							owl:versionIRI ?value ;
+							.
+					}
+				}
+			''' ;
+		] ,
+		[
+			a sh:SPARQLConstraint ;
+			sh:message "CASE version IRIs are expected to have a fragment matching the versionInfo string in the master CASE ontology."@en ;
+			sh:select '''
+				SELECT $this ?value
+				WHERE {
+					$this owl:versionIRI ?value .
+					<https://ontology.caseontology.org/case/case> owl:versionInfo ?lCaseVersionInfo .
+					FILTER (
+						STRSTARTS (
+							STR($this),
+							"https://ontology.caseontology.org/"
+						)
+					)
+					FILTER (
+						STR(?value)
+						!= 
+						CONCAT(
+							STR($this),
+							"/",
+							?lCaseVersionInfo
+						)
+					)
+				}
+			''' ;
+		]
+		;
+	sh:targetClass owl:Ontology ;
+	.
+


### PR DESCRIPTION
Note that to isolate effects of adding versioning, the `Feature-UCO-Issue-437-0.7.1` branch was started at the beginning of develop after the 0.7.0 release. There is also a dependency on UCO's 0.9.1 release being made first.  So, this PR needs to be handled in the order of the coordination checklist.

# Coordination

- [x] [Release page made](https://github.com/casework/casework.github.io/pull/204) on CASE website
- [x] [UCO PR 480](https://github.com/ucoProject/UCO/pull/480) merged
- [x] UCO submodule updated to track 0.9.1 tag