### PR TITLE
UCO Issue 493: Trigger CI on all branches starting with "develop" and "unstable"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ name: Continuous Integration
 
 on:
   push:
-    branches: [ master, develop ]
+    branches: [ master, develop*, unstable* ]
   pull_request:
-    branches: [ master, develop ]
+    branches: [ master, develop*, unstable* ]
 
 jobs:
   build:


### PR DESCRIPTION
This Pull Request is part of resolving [UCO Issue 493](https://github.com/ucoProject/UCO/issues/493).


# Coordination

- [x] Pull Request is against correct branch
- [x] Pull Request is in, or reverted to, Draft status before Solutions Approval vote has passed.
- [x] CI passes in CASE feature branch
- [x] CI passes in CASE current `unstable` branch ([1994f18](https://github.com/casework/CASE-Archive/commit/1994f1837ccbeca9666697316f088de0c9fb0476))
- [x] Impact on SHACL validation reviewed for CASE-Examples *(skipped)*
- [x] Impact on SHACL validation remediated for CASE-Examples *(skipped)*
- [x] Impact on SHACL validation reviewed for casework.github.io *(skipped)*
- [x] Impact on SHACL validation remediated for casework.github.io *(skipped)*
- [x] Milestone linked
- [x] Solutions Approval vote logged on corresponding Issue (once logged, can be taken out of Draft PR status) <!-- Non-applicable for PRs functioning under bugfix worflow -->