### PR TITLE
Update change request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/change-request.md
+++ b/.github/ISSUE_TEMPLATE/change-request.md
@@ -96,4 +96,6 @@ Some requirements are narrow enough they could be considered "Self-documenting."
 > Requirement 1 also fully describes the solution, implemented in [PR X](https://github.com/ucoProject/UCO/pull/X).
 
 If there is an accompanying pull request, please do link it under the "Development" box on the right of the Issues page.
+
+If example snippets of instance data are provided, please note if you provide permission for the examples to be transcribed to one of the tested example repositories (such as CASE-Examples).  This is a significant aid in confirming examples represent the semantics that the submitter intended.  "I am fine with my examples being transcribed and credited" should be sufficient.
 -->


### PR DESCRIPTION
This patch series ports [UCO PR 579](https://github.com/ucoProject/UCO/pull/579).

This is an update to GitHub templating. As a matter of GitHub interface programming, committee review is not required.