### PR TITLE
UCO Issue 640: Link `core:informalType` as parent of type-describing properties

### DIFF
--- a/ontology/investigation/investigation.ttl
+++ b/ontology/investigation/investigation.ttl
@@ -267,6 +267,7 @@ investigation:authorizationIdentifier
 
 investigation:authorizationType
 	a owl:DatatypeProperty ;
+	rdfs:subPropertyOf uco-core:informalType ;
 	rdfs:label "authorizationType"@en ;
 	rdfs:comment "A label categorizing a type of authorization (e.g. warrant)"@en ;
 	rdfs:range xsd:string ;
@@ -288,6 +289,7 @@ investigation:focus
 
 investigation:investigationForm
 	a owl:DatatypeProperty ;
+	rdfs:subPropertyOf uco-core:informalType ;
 	rdfs:label "investigationForm"@en ;
 	rdfs:comment "A label categorizing a type of investigation (case, incident, suspicious-activity, etc.)"@en ;
 	rdfs:range [


### PR DESCRIPTION
This pull request's review details are being tracked on [UCO PR 641](https://github.com/ucoProject/UCO/pull/641). Voting progress is being tracked on https://github.com/ucoProject/UCO/issues/640.