### PR TITLE
Bump GitHub Actions, and UCO to current state of develop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-java@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: '11'


### PR DESCRIPTION
This is a maintenance Pull Request, incorporating no new features.  This forward-ports UCO PRs [638](https://github.com/ucoProject/UCO/pull/638) and [639](https://github.com/ucoProject/UCO/pull/639), though none of the effects of 638 happened to re-occur when regenerating CASE's test results.

Once CI passes, this PR can be merged.