### PR TITLE
Issue 167: Adjust top Makefile dependency ordering in submodule initialization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,6 @@ all: \
 
 # The two CASE-Utility... files are to trigger rebuilds based on command-line interface changes or version increments.
 .venv.done.log: \
-  .git_submodule_init.done.log \
   dependencies/UCO/dependencies/CASE-Utility-SHACL-Inheritance-Reviewer/case_shacl_inheritance_reviewer/__init__.py \
   dependencies/UCO/dependencies/CASE-Utility-SHACL-Inheritance-Reviewer/setup.cfg \
   dependencies/UCO/requirements.txt
@@ -103,14 +102,26 @@ clean:
 	@rm -rf \
 	  venv
 
+# This recipe maintains timestamp order.
+# The target file creation is handled by recursive initialization done
+# in the recipe for .git_submodule_init.done.log.
 dependencies/UCO/dependencies/CASE-Utility-SHACL-Inheritance-Reviewer/case_shacl_inheritance_reviewer/__init__.py: \
   .git_submodule_init.done.log
-	$(MAKE) \
-	  --directory dependencies/UCO \
-	  dependencies/CASE-Utility-SHACL-Inheritance-Reviewer/case_shacl_inheritance_reviewer/__init__.py
+	test -r $@
+	touch -c $@
 
+# This recipe maintains timestamp order.
+# The target file creation is handled by recursive initialization done
+# in the recipe for .git_submodule_init.done.log.
 dependencies/UCO/dependencies/CASE-Utility-SHACL-Inheritance-Reviewer/setup.cfg: \
   .git_submodule_init.done.log
-	$(MAKE) \
-	  --directory dependencies/UCO \
-	  dependencies/CASE-Utility-SHACL-Inheritance-Reviewer/setup.cfg
+	test -r $@
+	touch -c $@
+
+# This recipe maintains timestamp order.
+# The target file creation is handled by initialization done in the
+# recipe for .git_submodule_init.done.log.
+dependencies/UCO/requirements.txt: \
+  .git_submodule_init.done.log
+	test -r $@
+	touch -c $@


### PR DESCRIPTION
This Pull Request resolves the bug described in #167 .


# Coordination

- [x] Pull Request is against correct branch
- [x] Pull Request is started in Draft status
- [x] CI passes in CASE feature branch against `develop`
- [x] CI passes in CASE current `unstable` branch tracking UCO's `unstable` as submodule ([`d2e81b1`](https://github.com/casework/CASE-Archive/commit/d2e81b1e6adf3626b3922e6a5b0a4076e403162f))
- [x] Impact on SHACL validation [reviewed](https://github.com/casework/CASE-Corpora/commit/957d0ebcd4e25cba13c8aa8bcd7c11b0062b0d3d) for CASE-Corpora
- [x] Impact on SHACL validation remediated for CASE-Corpora *(N/A)*
- [x] Impact on SHACL validation [reviewed](https://github.com/casework/CASE-Examples/commit/a445fd1a8d89314e63a450ad585190e0cf0179a2) for CASE-Examples
- [x] Impact on SHACL validation remediated for CASE-Examples *(N/A)*
- [x] Impact on SHACL validation [reviewed](https://github.com/casework/casework.github.io/pull/320/commits/8f69f005afdcb808dcebff8350a2995ab8b83be0) for casework.github.io
- [x] Impact on SHACL validation remediated for casework.github.io *(N/A)*
- [x] Milestone linked
- [x] Solutions Approval vote logged on corresponding Issue *(N/A)*