### PR TITLE
UCO Issue 640: Link core:informalType as parent of type-describing properties (for CASE 2.0.0)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,6 @@ all: \
 
 # The two CASE-Utility... files are to trigger rebuilds based on command-line interface changes or version increments.
 .venv.done.log: \
-  .git_submodule_init.done.log \
   dependencies/UCO/dependencies/CASE-Utility-SHACL-Inheritance-Reviewer/case_shacl_inheritance_reviewer/__init__.py \
   dependencies/UCO/dependencies/CASE-Utility-SHACL-Inheritance-Reviewer/setup.cfg \
   dependencies/UCO/requirements.txt
@@ -103,14 +102,26 @@ clean:
 	@rm -rf \
 	  venv
 
+# This recipe maintains timestamp order.
+# The target file creation is handled by recursive initialization done
+# in the recipe for .git_submodule_init.done.log.
 dependencies/UCO/dependencies/CASE-Utility-SHACL-Inheritance-Reviewer/case_shacl_inheritance_reviewer/__init__.py: \
   .git_submodule_init.done.log
-	$(MAKE) \
-	  --directory dependencies/UCO \
-	  dependencies/CASE-Utility-SHACL-Inheritance-Reviewer/case_shacl_inheritance_reviewer/__init__.py
+	test -r $@
+	touch -c $@
 
+# This recipe maintains timestamp order.
+# The target file creation is handled by recursive initialization done
+# in the recipe for .git_submodule_init.done.log.
 dependencies/UCO/dependencies/CASE-Utility-SHACL-Inheritance-Reviewer/setup.cfg: \
   .git_submodule_init.done.log
-	$(MAKE) \
-	  --directory dependencies/UCO \
-	  dependencies/CASE-Utility-SHACL-Inheritance-Reviewer/setup.cfg
+	test -r $@
+	touch -c $@
+
+# This recipe maintains timestamp order.
+# The target file creation is handled by initialization done in the
+# recipe for .git_submodule_init.done.log.
+dependencies/UCO/requirements.txt: \
+  .git_submodule_init.done.log
+	test -r $@
+	touch -c $@

--- a/ontology/investigation/investigation.ttl
+++ b/ontology/investigation/investigation.ttl
@@ -267,6 +267,7 @@ investigation:authorizationIdentifier
 
 investigation:authorizationType
 	a owl:DatatypeProperty ;
+	rdfs:subPropertyOf uco-core:informalType ;
 	rdfs:label "authorizationType"@en ;
 	rdfs:comment "A label categorizing a type of authorization (e.g. warrant)"@en ;
 	rdfs:range xsd:string ;
@@ -288,6 +289,7 @@ investigation:focus
 
 investigation:investigationForm
 	a owl:DatatypeProperty ;
+	rdfs:subPropertyOf uco-core:informalType ;
 	rdfs:label "investigationForm"@en ;
 	rdfs:comment "A label categorizing a type of investigation (case, incident, suspicious-activity, etc.)"@en ;
 	rdfs:range [


### PR DESCRIPTION
This PR does not require committee processing for merging. It should pass CI and receive an approving review, though.

This PR is part of implementing [UCO Issue 640](https://github.com/ucoProject/UCO/issues/640) in CASE, bringing forward changes to CASE 2.0.0.  New features were only new to CASE 1.4.0; no further change occurs for CASE 2.0.0 aside from catch-up merging.