### PR TITLE
UCO Issue 629: Enforce vocabulary pattern revision (adding CASE 1.4.0 changes)

### DIFF
--- a/ontology/investigation/investigation.ttl
+++ b/ontology/investigation/investigation.ttl
@@ -105,6 +105,7 @@ investigation:Investigation
 	rdfs:label "Investigation"@en ;
 	rdfs:comment "An investigation is a grouping of characteristics unique to an exploration of the facts involved in a cyber-relevant set of suspicious activity."@en ;
 	sh:property
+		investigation:Investigation-investigationForm-in-shape ,
 		[
 			sh:class investigation:Authorization ;
 			sh:nodeKind sh:BlankNodeOrIRI ;
@@ -140,22 +141,24 @@ investigation:Investigation
 			sh:path investigation:focus ;
 		] ,
 		[
-			sh:in (
-				"case"
-				"incident"
-				"suspicious-activity"
-			) ;
-			sh:message "Value is not member of the vocabulary InvestigationFormVocab." ;
-			sh:path investigation:investigationForm ;
-			sh:severity sh:Info ;
-		] ,
-		[
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
 			sh:path investigation:investigationForm ;
 		]
 		;
 	sh:targetClass investigation:Investigation ;
+	.
+
+investigation:Investigation-investigationForm-in-shape
+	a sh:PropertyShape ;
+	sh:in (
+		"case"
+		"incident"
+		"suspicious-activity"
+	) ;
+	sh:message "Value is not member of the vocabulary InvestigationFormVocab." ;
+	sh:path investigation:investigationForm ;
+	sh:severity sh:Info ;
 	.
 
 investigation:InvestigativeAction

--- a/ontology/investigation/investigation.ttl
+++ b/ontology/investigation/investigation.ttl
@@ -130,43 +130,28 @@ investigation:Investigation
 		] ,
 		[
 			sh:datatype xsd:string ;
+			sh:message "As of CASE 1.4.0, the datatype to use for investigation:investigationForm should be xsd:string.  Not using xsd:string will be an error in CASE 2.0.0." ;
+			sh:path investigation:investigationForm ;
+			sh:severity sh:Warning ;
+		] ,
+		[
+			sh:datatype xsd:string ;
 			sh:nodeKind sh:Literal ;
 			sh:path investigation:focus ;
 		] ,
 		[
-			sh:datatype vocabulary:InvestigationFormVocab ;
-			sh:message "Value is outside the default vocabulary InvestigationFormVocab." ;
+			sh:in (
+				"case"
+				"incident"
+				"suspicious-activity"
+			) ;
+			sh:message "Value is not member of the vocabulary InvestigationFormVocab." ;
 			sh:path investigation:investigationForm ;
 			sh:severity sh:Info ;
 		] ,
 		[
 			sh:maxCount "1"^^xsd:integer ;
 			sh:nodeKind sh:Literal ;
-			sh:or (
-				[
-					sh:datatype vocabulary:InvestigationFormVocab ;
-				]
-				[
-					sh:datatype xsd:string ;
-				]
-			) ;
-			sh:path investigation:investigationForm ;
-		] ,
-		[
-			sh:message "Value is not member of the vocabulary InvestigationFormVocab." ;
-			sh:or (
-				[
-					sh:datatype vocabulary:InvestigationFormVocab ;
-					sh:in (
-						"case"^^vocabulary:InvestigationFormVocab
-						"incident"^^vocabulary:InvestigationFormVocab
-						"suspicious-activity"^^vocabulary:InvestigationFormVocab
-					) ;
-				]
-				[
-					sh:datatype xsd:string ;
-				]
-			) ;
 			sh:path investigation:investigationForm ;
 		]
 		;

--- a/ontology/vocabulary/vocabulary.ttl
+++ b/ontology/vocabulary/vocabulary.ttl
@@ -19,9 +19,9 @@ vocab:InvestigationFormVocab
 	owl:equivalentClass [
 		a rdfs:Datatype ;
 		owl:oneOf (
-			"case"^^vocab:InvestigationFormVocab
-			"incident"^^vocab:InvestigationFormVocab
-			"suspicious-activity"^^vocab:InvestigationFormVocab
+			"case"
+			"incident"
+			"suspicious-activity"
 		) ;
 	] ;
 	.


### PR DESCRIPTION
This is a follow-on to #173 , which had done half the changes needed for CASE-2.0.0: UCO's pointer was updated, but the `develop` (CASE 1.4.0) changes hadn't been incorporated.