### PR TITLE
Typo: ExaminerActionLifecylce must be ExaminerActionLifecycle

### DIFF
--- a/ontology/investigation/investigation.ttl
+++ b/ontology/investigation/investigation.ttl
@@ -93,7 +93,7 @@ investigation:ExaminerActionLifecycle
 	rdfs:subClassOf uco-action:ActionLifecycle ;
 	rdfs:label "ExaminerActionLifecycle"@en ;
 	rdfs:comment "An examiner action lifecycle is an action pattern consisting of an ordered set of actions or subordinate action-lifecycles performed by an entity acting in a role involved in providing scientific evaluations of evidence that is used to aid law enforcement investigations and court cases."@en ;
-	sh:targetClass investigation:ExaminerActionLifecylce ;
+	sh:targetClass investigation:ExaminerActionLifecycle ;
 	.
 
 investigation:Investigation


### PR DESCRIPTION
# Typo: ExaminerActionLifecylce must be ExaminerActionLifecycle

The `investigation:ExaminerActionLifecycle` node shape aims `sh:targetClass` at `investigation:ExaminerActionLifecylce`, an IRI that is not a class. The class IRI and the `rdfs:label` already use `Lifecycle`. Sibling shapes `SubjectActionLifecycle` and `VictimActionLifecycle` already target correctly.

This packet adds the missing `c`. One token. The ChangeLog 1.5.0 stamp is C9. No new terms.

## Files

1. `ontology/investigation/investigation.ttl` — L96 `sh:targetClass` only

## Out of scope

- C9 (ChangeLog / Release CASE 1.5.0 stamp)
- New terms or a 1.6.0 release
- Sibling shapes (already correct)
- Tests, QC, or CI

## How to review

The dest is that one token. L88 and L94 already use `Lifecycle`. Only the `sh:targetClass` object was missing the `c`.

I am a volunteer. Thank you for the time. I am trying to become more useful on this work, so I welcome a critical look. If this is the wrong cut, or you want me to stand down, say so and I will recut from notes.
