### PR TITLE
ChangeLog needs the Release CASE 1.5.0 stamp

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2026-07-24
+	* Release CASE 1.5.0, with release notes at https://caseontology.org/releases/1.5.0/
+
 2026-07-23
 	* (217b29b) UCO Issue 666: Fix typo; add class-vs-instance clarifying remarks 
 


### PR DESCRIPTION
# ChangeLog needs the Release CASE 1.5.0 stamp

The in-repo ChangeLog still ends its release line at `2025-05-29 OCCASE-496: Release CASE 1.4.0`, after CASE 1.5.0 was published. The 2026-07-19 and 2026-07-23 bullets record the UCO 1.5.0 adopt and typo fixes. There is no `Release CASE 1.5.0` line. GitHub tag `1.5.0` and https://caseontology.org/releases/1.5.0/ are dated 2026-07-24. `ontology/master/case.ttl` already has `owl:versionIRI` 1.5.0.

This packet adds one stamp in the existing style, dated 2026-07-24, pointing at those notes. No feature bullets. I do not have an OCCASE ticket id, so the line has none.

## Files

1. `ChangeLog` — one dated block at the top

## Out of scope

- C8 (`ExaminerActionLifecylce` typo)
- Invented feature bullets from the 1.5.0 notes
- Rewriting prior ChangeLog entries
- Ontology or `versionIRI` edits (`case.ttl` is already 1.5.0)

## How to review

The dest is one dated block and one bullet. Compare to the `2025-05-29` 1.4.0 stamp. If you have an OCCASE id, add it the same way as OCCASE-496.

I am a volunteer. Thank you for the time. I am trying to become more useful on this work, so I welcome a critical look. If this is the wrong cut, or you want me to stand down, say so and I will recut from notes.
