### PR TITLE
fix: correct ExaminerActionLifecylce to ExaminerActionLifecycle (missing 'c')

### DIFF
--- a/ontology/investigation/investigation.ttl
+++ b/ontology/investigation/investigation.ttl
@@ -93,7 +93,7 @@ investigation:ExaminerActionLifecycle
 	rdfs:subClassOf uco-action:ActionLifecycle ;
 	rdfs:label "ExaminerActionLifecycle"@en ;
 	rdfs:comment "An examiner action lifecycle is an action pattern consisting of an ordered set of actions or subordinate action-lifecycles performed by an entity acting in a role involved in providing scientific evaluations of evidence that is used to aid law enforcement investigations and court cases."@en ;
-	sh:targetClass investigation:ExaminerActionLifecylce ;
+	sh:targetClass investigation:ExaminerActionLifecycle ;
 	.
 
 investigation:Investigation


### PR DESCRIPTION
## Description
Fixes a typo in `ontology/investigation/investigation.ttl` line 96.

The `sh:targetClass` property incorrectly pointed to `investigation:ExaminerActionLifecylce` (missing 'c'), but the actual class is defined as `investigation:ExaminerActionLifecycle`.

## Changes
- Changed `investigation:ExaminerActionLifecylce` → `investigation:ExaminerActionLifecycle` in line 96

## Fixes
Fixes #207